### PR TITLE
Added media stream API support for IOS devices & show capture picture icon

### DIFF
--- a/app/css/styles.css
+++ b/app/css/styles.css
@@ -9,8 +9,8 @@ body {
   position: absolute;
   width: 100%;
   height: 100%;
-  -webkit-overflow-scrolling: touch;
   overflow: hidden;
+  background-color: rgba(0, 0, 0, 0.5);
 }
 
 .app__header {
@@ -212,7 +212,7 @@ video {
 
 .app__snackbar {
   position: fixed;
-  bottom: 20px;
+  bottom: 15px;
   left: 20px;
   pointer-events: none;
   z-index: 9999;
@@ -319,17 +319,39 @@ video {
 
 .app__overlay {
   position: fixed;
-  top: -56px;
+  top: 0;
   bottom: 0;
   right: 0;
   left: 0;
-  border-color: #ffffff;
-  border-width: 2px;
   transition: all 200ms ease-in;
-  width: 360px;
-  height: 360px;
+  width: 320px;
+  height: 320px;
   margin: auto;
-  border-radius: 2px;
+}
+
+
+.app__overlay-left,
+.app__overlay-right {
+  width: 52px;
+  height: 340px;
+  background: #7f7f7f;
+}
+
+.app__overlay-left {
+  margin-left: -57px;
+  margin-top: -10px;
+}
+
+.app__overlay-right {
+  margin-right: -57px;
+  margin-top: -340px;
+  float: right;
+}
+
+.app__overlay {
+  /* border-color: #ffffff;
+  border-width: 5px; */
+  border: 0;
 }
 
 .app__help-text,
@@ -386,4 +408,9 @@ video {
 
 input[type='file'] {
   display: none;
+}
+
+#frame {
+  width: auto;
+  height: auto;
 }

--- a/app/css/styles.css
+++ b/app/css/styles.css
@@ -266,7 +266,7 @@ video {
   box-shadow: 0 9px 46px 8px rgba(0,0,0,.14), 0 11px 15px -7px rgba(0,0,0,.12), 0 24px 38px 3px rgba(0,0,0,.2);
 }
 
-.app__dialog h5 { 
+.app__dialog h5 {
   margin-top: 20px;
   margin-left: 18px;
   font-weight: 500;
@@ -297,7 +297,7 @@ video {
   border: 0;
   height: 35px;
   width: 70px;
-  font-size: 15px;
+  font-size: 16px;
   background: transparent;
   font-weight: 500;
   outline: none;
@@ -338,11 +338,14 @@ video {
   position: absolute;
   bottom: -70px;
   font-size: 18px;
-  left: 0;
   right: 0;
   text-align: center;
   user-select: none;
+}
+
+.app__help-text {
   display: none;
+  left: 0;
 }
 
 .app__dialog-overlay {
@@ -363,19 +366,24 @@ video {
 }
 
 .app__select-photos {
-  font-size: 19px;
-  font-weight: 500;
-  width: 250px;
-  height: 35px;
-  line-height: 35px;
-  margin: 0 auto;
+  width: 58px;
+  height: 58px;
   cursor: pointer;
   position: fixed;
   bottom: 20px;
-  text-transform: uppercase;
+  right: 20px;
+  border-radius: 50%;
+  background-color: #3F51B5;
+  background-image: url("/images/photo-camera.svg");
+  background-repeat: no-repeat;
+  background-size: 26px;
+  background-position: 16px 15px;
 }
 
 .app__select-photos:active {
-  opacity: 0.9;
-  transform: scale(0.98);
+  opacity: 0.8;
+}
+
+input[type='file'] {
+  display: none;
 }

--- a/app/images/photo-camera.svg
+++ b/app/images/photo-camera.svg
@@ -1,0 +1,9 @@
+<svg fill="#fff" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="24" height="24" viewBox="0 0 24 24">
+    <defs>
+        <path id="a" d="M24 24H0V0h24v24z"/>
+    </defs>
+    <clipPath id="b">
+        <use xlink:href="#a" overflow="visible"/>
+    </clipPath>
+    <path clip-path="url(#b)" d="M3 4V1h2v3h3v2H5v3H3V6H0V4h3zm3 6V7h3V4h7l1.83 2H21c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H5c-1.1 0-2-.9-2-2V10h3zm7 9c2.76 0 5-2.24 5-5s-2.24-5-5-5-5 2.24-5 5 2.24 5 5 5zm-3.2-5c0 1.77 1.43 3.2 3.2 3.2s3.2-1.43 3.2-3.2-1.43-3.2-3.2-3.2-3.2 1.43-3.2 3.2z"/>
+</svg>

--- a/app/index.html
+++ b/app/index.html
@@ -74,5 +74,7 @@
         ga('create', 'pageview');
       }
     </script>
+    <script async src="https://cdn.jsdelivr.net/npm/pwacompat@2.0.6/pwacompat.min.js" integrity="sha384-GOaSLecPIMCJksN83HLuYf9FToOiQ2Df0+0ntv7ey8zjUHESXhthwvq9hXAZTifA"
+      crossorigin="anonymous"></script>
   </body>
 </html>

--- a/app/index.html
+++ b/app/index.html
@@ -7,18 +7,19 @@
     <meta name=description content="QR Code Scanner is the fastest and most user-friendly web application.">
     <meta name="viewport" content="width=device-width,initial-scale=1.0">
     <meta name="mobile-web-app-capable" content="yes">
-    <meta name="apple-mobile-web-app-title" content="QR Scanner"/>
+    <meta name="apple-mobile-web-app-title" content="QR Scanner" />
     <meta name="apple-mobile-web-app-status-bar-style" content="#e4e4e4">
     <meta name="apple-mobile-web-app-capable" content="yes">
-    <meta name="application-name" content="QR Scanner"/>
-    <meta name="msapplication-TileColor" content="#e4e4e4"/>
-    <meta name="msapplication-TileImage" content="/images/touch/mstile-150x150.png"/>
-    <meta name="theme-color" content="#fff"/>
-    <link rel="apple-touch-icon" href="/images/touch/apple-touch-icon.jpg"/>
-    <link rel="icon" type="image/png" href="/images/touch/favicon-32x32.png" sizes="32x32"/>
-    <link rel="icon" type="image/png" href="/images/touch/favicon-16x16.png" sizes="16x16"/>
+    <meta name="application-name" content="QR Scanner" />
+    <meta name="msapplication-TileColor" content="#e4e4e4" />
+    <meta name="msapplication-TileImage" content="/images/touch/mstile-150x150.png" />
+    <meta name="theme-color" content="#fff" />
+    <link rel="apple-touch-icon" href="/images/touch/apple-touch-icon.jpg" />
+    <link rel="icon" type="image/png" href="/images/touch/favicon-32x32.png" sizes="32x32" />
+    <link rel="icon" type="image/png" href="/images/touch/favicon-16x16.png" sizes="16x16" />
     <link rel="shortcut icon" href="/images/touch/favicon.ico">
     <link rel="manifest" href="/manifest.json">
+    <link rel="preload" as="script" href="/decoder.min.js">
   </head>
   <body>
     <div class="app__layout">
@@ -26,15 +27,16 @@
       <header class="app__header">
         <span class="app__header-icon" onclick="window.open('https://github.com/code-kotis/barcode-scanner', '_blank', 'toolbar=0,location=0,menubar=0');">
           <svg fill="#FFFFFF" height="27" viewBox="0 0 24 24" width="27" xmlns="http://www.w3.org/2000/svg">
-            <path d="M0 0h24v24H0z" fill="none"/>
-            <path d="M11 17h2v-6h-2v6zm1-15C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8zM11 9h2V7h-2v2z"/>
+            <path d="M0 0h24v24H0z" fill="none" />
+            <path d="M11 17h2v-6h-2v6zm1-15C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8zM11 9h2V7h-2v2z"
+            />
           </svg>
         </span>
       </header>
-      
+
       <main class="app__layout-content">
         <video autoplay></video>
-        
+
         <!-- Dialog  -->
         <div class="app__dialog app__dialog--hide">
           <div class="app__dialog-content">
@@ -57,16 +59,18 @@
       <div class="app__overlay-frame"></div>
       <!-- Scanner animation -->
       <div class="custom-scanner"></div>
-      <div class="app__help-text">Point your camera at a QR Code</div>
-      <div class="app__select-photos">Select from photos</div>
+      <div class="app__help-text">Your browser doesn't support Camera API</div>
+      <div class="app__select-photos"></div>
     </div>
-    
+
     <script>
       if (location.hostname !== "localhost") {
-        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-        (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-        m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+        (function (i, s, o, g, r, a, m) {
+          i['GoogleAnalyticsObject'] = r; i[r] = i[r] || function () {
+            (i[r].q = i[r].q || []).push(arguments)
+          }, i[r].l = 1 * new Date(); a = s.createElement(o),
+            m = s.getElementsByTagName(o)[0]; a.async = 1; a.src = g; m.parentNode.insertBefore(a, m)
+        })(window, document, 'script', '//www.google-analytics.com/analytics.js', 'ga');
         ga('create', 'pageview');
       }
     </script>

--- a/app/index.html
+++ b/app/index.html
@@ -59,9 +59,10 @@
       <div class="app__overlay-frame"></div>
       <!-- Scanner animation -->
       <div class="custom-scanner"></div>
-      <div class="app__help-text">Your browser doesn't support Camera API</div>
-      <div class="app__select-photos"></div>
+      <div class="app__help-text"></div>
     </div>
+
+    <div class="app__select-photos"></div>
 
     <script>
       if (location.hostname !== "localhost") {

--- a/app/js/main.js
+++ b/app/js/main.js
@@ -1,144 +1,150 @@
 import QRReader from './vendor/qrscan.js';
-import {snackbar} from './snackbar.js';
+import { snackbar } from './snackbar.js';
 import styles from '../css/styles.css';
 import isURL from 'is-url';
 
 //If service worker is installed, show offline usage notification
-if ("serviceWorker" in navigator) {
-  navigator.serviceWorker.ready.then((registration) => {
-    if (!localStorage.getItem("offline")) {
-      localStorage.setItem("offline", true);
-      snackbar.show('App is ready for offline usage.', 5000);
-    }
-  });
+if ('serviceWorker' in navigator && window.location.hostname !== 'localhost') {
+	navigator.serviceWorker.ready.then(registration => {
+		if (!localStorage.getItem('offline')) {
+			localStorage.setItem('offline', true);
+			snackbar.show('App is ready for offline usage.', 5000);
+		}
+	});
 }
 
 //To generate sw.js file
 if (process.env.NODE_ENV === 'production') {
-  require('offline-plugin/runtime').install();
+	require('offline-plugin/runtime').install();
 }
 
-window.addEventListener("DOMContentLoaded", () => {
-  //To check the device and add iOS support
-  window.iOS = ["iPad", "iPhone", "iPod"].indexOf(navigator.platform) >= 0;
-  window.isMediaStreamAPISupported = (navigator && navigator.mediaDevices && 'enumerateDevices' in navigator.mediaDevices);
+window.addEventListener('DOMContentLoaded', () => {
+	//To check the device and add iOS support
+	window.iOS = ['iPad', 'iPhone', 'iPod'].indexOf(navigator.platform) >= 0;
+	window.isMediaStreamAPISupported = navigator && navigator.mediaDevices && 'enumerateDevices' in navigator.mediaDevices;
+	window.noCameraPermission = false;
 
-  var copiedText = null;
-  var frame = null;
-  var selectPhotoBtn = document.querySelector('.app__select-photos');
-  var dialogElement = document.querySelector('.app__dialog');
-  var dialogOverlayElement = document.querySelector('.app__dialog-overlay');
-  var dialogOpenBtnElement = document.querySelector('.app__dialog-open');
-  var dialogCloseBtnElement = document.querySelector('.app__dialog-close');
-  var scanningEle = document.querySelector('.custom-scanner');
-  var textBoxEle = document.querySelector('#result');
-  var helpTextEle = document.querySelector('.app__help-text');
-  var infoSvg = document.querySelector('.app__header-icon svg');
-  var videoElement = document.querySelector('video');
-  window.appOverlay = document.querySelector('.app__overlay');
+	var copiedText = null;
+	var frame = null;
+	var selectPhotoBtn = document.querySelector('.app__select-photos');
+	var dialogElement = document.querySelector('.app__dialog');
+	var dialogOverlayElement = document.querySelector('.app__dialog-overlay');
+	var dialogOpenBtnElement = document.querySelector('.app__dialog-open');
+	var dialogCloseBtnElement = document.querySelector('.app__dialog-close');
+	var scanningEle = document.querySelector('.custom-scanner');
+	var textBoxEle = document.querySelector('#result');
+	var helpTextEle = document.querySelector('.app__help-text');
+	var infoSvg = document.querySelector('.app__header-icon svg');
+	var videoElement = document.querySelector('video');
+	window.appOverlay = document.querySelector('.app__overlay');
 
-  //Initializing qr scanner
-  window.addEventListener('load', (event) => {
-    QRReader.init(); //To initialize QR Scanner
-    // Set camera overlay size
-    setTimeout(() => {
-      setCameraOverlay();
-      if (window.isMediaStreamAPISupported) {
-        scan();
-      }
-    }, 1000);
+	//Initializing qr scanner
+	window.addEventListener('load', event => {
+		QRReader.init(); //To initialize QR Scanner
+		// Set camera overlay size
+		setTimeout(() => {
+			setCameraOverlay();
+			if (window.isMediaStreamAPISupported) {
+				scan();
+			}
+		}, 1000);
 
-    // To support other browsers who dont have mediaStreamAPI
-    selectFromPhoto();
-  });
+		// To support other browsers who dont have mediaStreamAPI
+		selectFromPhoto();
+	});
 
-  function setCameraOverlay() {
-    window.appOverlay.style.borderStyle = 'solid';
-  }
+	function setCameraOverlay() {
+		window.appOverlay.style.borderStyle = 'solid';
+	}
 
-  function createFrame() {
-    frame = document.createElement('img');
-    frame.src = '';
-    frame.id = 'frame';
-  }
+	function createFrame() {
+		frame = document.createElement('img');
+		frame.src = '';
+		frame.id = 'frame';
+	}
 
-  //Dialog close btn event
-  dialogCloseBtnElement.addEventListener('click', hideDialog, false);
-  dialogOpenBtnElement.addEventListener('click', openInBrowser, false);
+	//Dialog close btn event
+	dialogCloseBtnElement.addEventListener('click', hideDialog, false);
+	dialogOpenBtnElement.addEventListener('click', openInBrowser, false);
 
-  //To open result in browser
-  function openInBrowser() {
-    console.log('Result: ', copiedText);
-    window.open(copiedText, '_blank', 'toolbar=0,location=0,menubar=0');
-    copiedText = null;
-    hideDialog();
-  }
+	//To open result in browser
+	function openInBrowser() {
+		console.log('Result: ', copiedText);
+		window.open(copiedText, '_blank', 'toolbar=0,location=0,menubar=0');
+		copiedText = null;
+		hideDialog();
+	}
 
-  //Scan
-  function scan(forSelectedPhotos = false) {
-    if (window.isMediaStreamAPISupported) scanningEle.style.display = 'block';
-    else { helpTextEle.style.display = 'block'; }
-    QRReader.scan((result) => {
+	//Scan
+	function scan(forSelectedPhotos = false) {
+		if (window.isMediaStreamAPISupported && !window.noCameraPermission) {
+			scanningEle.style.display = 'block';
+		}
 
-      copiedText = result;
-      textBoxEle.value = result;
-      textBoxEle.select();
-      scanningEle.style.display = 'none';
-      if (isURL(result)) {
-        dialogOpenBtnElement.style.display = 'inline-block';
-      }
-      dialogElement.classList.remove('app__dialog--hide');
-      dialogOverlayElement.classList.remove('app__dialog--hide');
-    }, forSelectedPhotos);
-  }
+		if (forSelectedPhotos) {
+			scanningEle.style.display = 'block';
+		}
 
-  //Hide dialog
-  function hideDialog() {
-    copiedText = null;
-    textBoxEle.value = "";
+		QRReader.scan(result => {
+			copiedText = result;
+			textBoxEle.value = result;
+			textBoxEle.select();
+			scanningEle.style.display = 'none';
+			if (isURL(result)) {
+				dialogOpenBtnElement.style.display = 'inline-block';
+			}
+			dialogElement.classList.remove('app__dialog--hide');
+			dialogOverlayElement.classList.remove('app__dialog--hide');
+			const frame = document.querySelector('#frame');
+			// if (forSelectedPhotos && frame) frame.remove();
+		}, forSelectedPhotos);
+	}
 
-    if (!window.isMediaStreamAPISupported) {
-      frame.src = "";
-      frame.className = "";
-    }
+	//Hide dialog
+	function hideDialog() {
+		copiedText = null;
+		textBoxEle.value = '';
 
-    dialogElement.classList.add('app__dialog--hide');
-    dialogOverlayElement.classList.add('app__dialog--hide');
-    scan();
-  }
+		if (!window.isMediaStreamAPISupported) {
+			frame.src = '';
+			frame.className = '';
+		}
 
-  function selectFromPhoto() {
-    //Creating the camera element
-    var camera = document.createElement('input');
-    camera.setAttribute('type', 'file');
-    camera.setAttribute('capture', 'camera');
-    camera.id = 'camera';
-    infoSvg.style.fill = '#212121';
-    window.appOverlay.style.borderStyle = '';
-    selectPhotoBtn.style.color = "#212121";
-    selectPhotoBtn.style.display = 'block';
-    createFrame();
+		dialogElement.classList.add('app__dialog--hide');
+		dialogOverlayElement.classList.add('app__dialog--hide');
+		scan();
+	}
 
-    //Add the camera and img element to DOM
-    var pageContentElement = document.querySelector('.app__layout-content');
-    pageContentElement.appendChild(camera);
-    pageContentElement.appendChild(frame);
+	function selectFromPhoto() {
+		//Creating the camera element
+		var camera = document.createElement('input');
+		camera.setAttribute('type', 'file');
+		camera.setAttribute('capture', 'camera');
+		camera.id = 'camera';
+		window.appOverlay.style.borderStyle = '';
+		selectPhotoBtn.style.display = 'block';
+		createFrame();
 
-    //Click of camera fab icon
-    selectPhotoBtn.addEventListener('click', () => {
-      scanningEle.style.display = 'none';
-      document.querySelector("#camera").click();
-    });
+		//Add the camera and img element to DOM
+		var pageContentElement = document.querySelector('.app__layout-content');
+		pageContentElement.appendChild(camera);
+		pageContentElement.appendChild(frame);
 
-    //On camera change
-    camera.addEventListener('change', (event) => {
-      if (event.target && event.target.files.length > 0) {
-        frame.className = 'app__overlay';
-        frame.src = URL.createObjectURL(event.target.files[0]);
-        scanningEle.style.display = 'block';
-        window.appOverlay.style.borderColor = '#212121';
-        scan();
-      }
-    });
-  }
+		//Click of camera fab icon
+		selectPhotoBtn.addEventListener('click', () => {
+			scanningEle.style.display = 'none';
+			document.querySelector('#camera').click();
+		});
+
+		//On camera change
+		camera.addEventListener('change', event => {
+			if (event.target && event.target.files.length > 0) {
+				frame.className = 'app__overlay';
+				frame.src = URL.createObjectURL(event.target.files[0]);
+				if (!window.noCameraPermission) scanningEle.style.display = 'block';
+				window.appOverlay.style.borderColor = 'rgb(62, 78, 184)';
+				scan(true);
+			}
+		});
+	}
 });

--- a/app/js/vendor/qrscan.js
+++ b/app/js/vendor/qrscan.js
@@ -94,7 +94,6 @@ QRReader.init = () => {
 					if (window.iOS) {
 						constraints.video.facingMode = 'environment';
 					}
-
 					startCapture(constraints);
 				} else if (device.length) {
 					constraints = {

--- a/package.json
+++ b/package.json
@@ -1,34 +1,34 @@
 {
-  "name": "barcodeScanner",
-  "version": "3.0.0",
-  "engines": {
-    "node": "4.1.1"
-  },
-  "dependencies": {
-    "is-url": "^1.2.2"
-  },
-  "devDependencies": {
-    "babel-core": "latest",
-    "babel-loader": "^6.2.8",
-    "babel-preset-env": "latest",
-    "copy-webpack-plugin": "^4.0.1",
-    "cross-env": "^5.0.1",
-    "css-loader": "^0.26.1",
-    "extract-text-webpack-plugin": "^2.1.0",
-    "html-webpack-plugin": "^2.24.1",
-    "image-webpack-loader": "^3.0.0",
-    "node-sass": "^3.13.0",
-    "offline-plugin": "^4.5.3",
-    "sass-loader": "^4.0.2",
-    "style-loader": "^0.13.1",
-    "uglify-js": "^2.7.5",
-    "vinyl-source-stream": "^1.1.0",
-    "webpack": "2.2.0",
-    "webpack-dev-server": "2.2.0"
-  },
-  "scripts": {
-    "start": "webpack-dev-server --hot --inline --open",
-    "deploy": "npm run build && bash deploy.sh",
-    "build": "cross-env NODE_ENV=production webpack -p --config webpack.config.js"
-  }
+	"name": "barcode-scanner",
+	"version": "3.0.0",
+	"engines": {
+		"node": ">=8.9.0"
+	},
+	"dependencies": {
+		"is-url": "^1.2.2"
+	},
+	"devDependencies": {
+		"babel-core": "latest",
+		"babel-loader": "^6.2.8",
+		"babel-preset-env": "latest",
+		"copy-webpack-plugin": "^4.0.1",
+		"cross-env": "^5.0.1",
+		"css-loader": "^0.26.1",
+		"extract-text-webpack-plugin": "^2.1.0",
+		"html-webpack-plugin": "^2.24.1",
+		"image-webpack-loader": "^3.0.0",
+		"node-sass": "^3.13.0",
+		"offline-plugin": "^4.5.3",
+		"sass-loader": "^4.0.2",
+		"style-loader": "^0.13.1",
+		"uglify-js": "^2.7.5",
+		"vinyl-source-stream": "^1.1.0",
+		"webpack": "2.2.0",
+		"webpack-dev-server": "2.2.0"
+	},
+	"scripts": {
+		"start": "webpack-dev-server --hot --inline --open",
+		"deploy": "npm run build && bash deploy.sh",
+		"build": "cross-env NODE_ENV=production webpack -p --config webpack.config.js"
+	}
 }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "barcode-scanner",
 	"version": "3.0.0",
 	"engines": {
-		"node": ">=8.9.0"
+		"node": ">=4.1.1"
 	},
 	"dependencies": {
 		"is-url": "^1.2.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -216,6 +216,14 @@ babel-code-frame@^6.11.0, babel-code-frame@^6.22.0:
     esutils "^2.0.2"
     js-tokens "^3.0.0"
 
+babel-code-frame@^6.26.0:
+  version "6.26.0"
+  resolved "https://registry.yarnpkg.com/babel-code-frame/-/babel-code-frame-6.26.0.tgz#63fd43f7dc1e3bb7ce35947db8fe369a3f58c74b"
+  dependencies:
+    chalk "^1.1.3"
+    esutils "^2.0.2"
+    js-tokens "^3.0.2"
+
 babel-core@^6.24.1, babel-core@latest:
   version "6.25.0"
   resolved "https://registry.yarnpkg.com/babel-core/-/babel-core-6.25.0.tgz#7dd42b0463c742e9d5296deb3ec67a9322dad729"
@@ -253,6 +261,14 @@ babel-generator@^6.25.0:
     source-map "^0.5.0"
     trim-right "^1.0.1"
 
+babel-helper-builder-binary-assignment-operator-visitor@^6.24.1:
+  version "6.24.1"
+  resolved "https://registry.yarnpkg.com/babel-helper-builder-binary-assignment-operator-visitor/-/babel-helper-builder-binary-assignment-operator-visitor-6.24.1.tgz#cce4517ada356f4220bcae8a02c2b346f9a56664"
+  dependencies:
+    babel-helper-explode-assignable-expression "^6.24.1"
+    babel-runtime "^6.22.0"
+    babel-types "^6.24.1"
+
 babel-helper-call-delegate@^6.24.1:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-helper-call-delegate/-/babel-helper-call-delegate-6.24.1.tgz#ece6aacddc76e41c3461f88bfc575bd0daa2df8d"
@@ -270,6 +286,14 @@ babel-helper-define-map@^6.24.1:
     babel-runtime "^6.22.0"
     babel-types "^6.24.1"
     lodash "^4.2.0"
+
+babel-helper-explode-assignable-expression@^6.24.1:
+  version "6.24.1"
+  resolved "https://registry.yarnpkg.com/babel-helper-explode-assignable-expression/-/babel-helper-explode-assignable-expression-6.24.1.tgz#f25b82cf7dc10433c55f70592d5746400ac22caa"
+  dependencies:
+    babel-runtime "^6.22.0"
+    babel-traverse "^6.24.1"
+    babel-types "^6.24.1"
 
 babel-helper-function-name@^6.24.1:
   version "6.24.1"
@@ -310,6 +334,16 @@ babel-helper-regex@^6.24.1:
     babel-types "^6.24.1"
     lodash "^4.2.0"
 
+babel-helper-remap-async-to-generator@^6.24.1:
+  version "6.24.1"
+  resolved "https://registry.yarnpkg.com/babel-helper-remap-async-to-generator/-/babel-helper-remap-async-to-generator-6.24.1.tgz#5ec581827ad723fecdd381f1c928390676e4551b"
+  dependencies:
+    babel-helper-function-name "^6.24.1"
+    babel-runtime "^6.22.0"
+    babel-template "^6.24.1"
+    babel-traverse "^6.24.1"
+    babel-types "^6.24.1"
+
 babel-helper-replace-supers@^6.24.1:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-helper-replace-supers/-/babel-helper-replace-supers-6.24.1.tgz#bf6dbfe43938d17369a213ca8a8bf74b6a90ab1a"
@@ -349,6 +383,26 @@ babel-plugin-check-es2015-constants@^6.22.0:
   dependencies:
     babel-runtime "^6.22.0"
 
+babel-plugin-syntax-async-functions@^6.8.0:
+  version "6.13.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz#cad9cad1191b5ad634bf30ae0872391e0647be95"
+
+babel-plugin-syntax-exponentiation-operator@^6.8.0:
+  version "6.13.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz#9ee7e8337290da95288201a6a57f4170317830de"
+
+babel-plugin-syntax-trailing-function-commas@^6.22.0:
+  version "6.22.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-6.22.0.tgz#ba0360937f8d06e40180a43fe0d5616fff532cf3"
+
+babel-plugin-transform-async-to-generator@^6.22.0:
+  version "6.24.1"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-async-to-generator/-/babel-plugin-transform-async-to-generator-6.24.1.tgz#6536e378aff6cb1d5517ac0e40eb3e9fc8d08761"
+  dependencies:
+    babel-helper-remap-async-to-generator "^6.24.1"
+    babel-plugin-syntax-async-functions "^6.8.0"
+    babel-runtime "^6.22.0"
+
 babel-plugin-transform-es2015-arrow-functions@^6.22.0:
   version "6.22.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.22.0.tgz#452692cb711d5f79dc7f85e440ce41b9f244d221"
@@ -361,17 +415,17 @@ babel-plugin-transform-es2015-block-scoped-functions@^6.22.0:
   dependencies:
     babel-runtime "^6.22.0"
 
-babel-plugin-transform-es2015-block-scoping@^6.24.1:
-  version "6.24.1"
-  resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.24.1.tgz#76c295dc3a4741b1665adfd3167215dcff32a576"
+babel-plugin-transform-es2015-block-scoping@^6.23.0:
+  version "6.26.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.26.0.tgz#d70f5299c1308d05c12f463813b0a09e73b1895f"
   dependencies:
-    babel-runtime "^6.22.0"
-    babel-template "^6.24.1"
-    babel-traverse "^6.24.1"
-    babel-types "^6.24.1"
-    lodash "^4.2.0"
+    babel-runtime "^6.26.0"
+    babel-template "^6.26.0"
+    babel-traverse "^6.26.0"
+    babel-types "^6.26.0"
+    lodash "^4.17.4"
 
-babel-plugin-transform-es2015-classes@^6.24.1:
+babel-plugin-transform-es2015-classes@^6.23.0:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.24.1.tgz#5a4c58a50c9c9461e564b4b2a3bfabc97a2584db"
   dependencies:
@@ -385,33 +439,33 @@ babel-plugin-transform-es2015-classes@^6.24.1:
     babel-traverse "^6.24.1"
     babel-types "^6.24.1"
 
-babel-plugin-transform-es2015-computed-properties@^6.24.1:
+babel-plugin-transform-es2015-computed-properties@^6.22.0:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.24.1.tgz#6fe2a8d16895d5634f4cd999b6d3480a308159b3"
   dependencies:
     babel-runtime "^6.22.0"
     babel-template "^6.24.1"
 
-babel-plugin-transform-es2015-destructuring@^6.22.0:
+babel-plugin-transform-es2015-destructuring@^6.23.0:
   version "6.23.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.23.0.tgz#997bb1f1ab967f682d2b0876fe358d60e765c56d"
   dependencies:
     babel-runtime "^6.22.0"
 
-babel-plugin-transform-es2015-duplicate-keys@^6.24.1:
+babel-plugin-transform-es2015-duplicate-keys@^6.22.0:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-6.24.1.tgz#73eb3d310ca969e3ef9ec91c53741a6f1576423e"
   dependencies:
     babel-runtime "^6.22.0"
     babel-types "^6.24.1"
 
-babel-plugin-transform-es2015-for-of@^6.22.0:
+babel-plugin-transform-es2015-for-of@^6.23.0:
   version "6.23.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.23.0.tgz#f47c95b2b613df1d3ecc2fdb7573623c75248691"
   dependencies:
     babel-runtime "^6.22.0"
 
-babel-plugin-transform-es2015-function-name@^6.24.1:
+babel-plugin-transform-es2015-function-name@^6.22.0:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.24.1.tgz#834c89853bc36b1af0f3a4c5dbaa94fd8eacaa8b"
   dependencies:
@@ -425,13 +479,22 @@ babel-plugin-transform-es2015-literals@^6.22.0:
   dependencies:
     babel-runtime "^6.22.0"
 
-babel-plugin-transform-es2015-modules-amd@^6.24.1:
+babel-plugin-transform-es2015-modules-amd@^6.22.0, babel-plugin-transform-es2015-modules-amd@^6.24.1:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-6.24.1.tgz#3b3e54017239842d6d19c3011c4bd2f00a00d154"
   dependencies:
     babel-plugin-transform-es2015-modules-commonjs "^6.24.1"
     babel-runtime "^6.22.0"
     babel-template "^6.24.1"
+
+babel-plugin-transform-es2015-modules-commonjs@^6.23.0:
+  version "6.26.2"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.26.2.tgz#58a793863a9e7ca870bdc5a881117ffac27db6f3"
+  dependencies:
+    babel-plugin-transform-strict-mode "^6.24.1"
+    babel-runtime "^6.26.0"
+    babel-template "^6.26.0"
+    babel-types "^6.26.0"
 
 babel-plugin-transform-es2015-modules-commonjs@^6.24.1:
   version "6.24.1"
@@ -442,7 +505,7 @@ babel-plugin-transform-es2015-modules-commonjs@^6.24.1:
     babel-template "^6.24.1"
     babel-types "^6.24.1"
 
-babel-plugin-transform-es2015-modules-systemjs@^6.24.1:
+babel-plugin-transform-es2015-modules-systemjs@^6.23.0:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-6.24.1.tgz#ff89a142b9119a906195f5f106ecf305d9407d23"
   dependencies:
@@ -450,7 +513,7 @@ babel-plugin-transform-es2015-modules-systemjs@^6.24.1:
     babel-runtime "^6.22.0"
     babel-template "^6.24.1"
 
-babel-plugin-transform-es2015-modules-umd@^6.24.1:
+babel-plugin-transform-es2015-modules-umd@^6.23.0:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-modules-umd/-/babel-plugin-transform-es2015-modules-umd-6.24.1.tgz#ac997e6285cd18ed6176adb607d602344ad38468"
   dependencies:
@@ -458,14 +521,14 @@ babel-plugin-transform-es2015-modules-umd@^6.24.1:
     babel-runtime "^6.22.0"
     babel-template "^6.24.1"
 
-babel-plugin-transform-es2015-object-super@^6.24.1:
+babel-plugin-transform-es2015-object-super@^6.22.0:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.24.1.tgz#24cef69ae21cb83a7f8603dad021f572eb278f8d"
   dependencies:
     babel-helper-replace-supers "^6.24.1"
     babel-runtime "^6.22.0"
 
-babel-plugin-transform-es2015-parameters@^6.24.1:
+babel-plugin-transform-es2015-parameters@^6.23.0:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.24.1.tgz#57ac351ab49caf14a97cd13b09f66fdf0a625f2b"
   dependencies:
@@ -476,7 +539,7 @@ babel-plugin-transform-es2015-parameters@^6.24.1:
     babel-traverse "^6.24.1"
     babel-types "^6.24.1"
 
-babel-plugin-transform-es2015-shorthand-properties@^6.24.1:
+babel-plugin-transform-es2015-shorthand-properties@^6.22.0:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.24.1.tgz#24f875d6721c87661bbd99a4622e51f14de38aa0"
   dependencies:
@@ -489,7 +552,7 @@ babel-plugin-transform-es2015-spread@^6.22.0:
   dependencies:
     babel-runtime "^6.22.0"
 
-babel-plugin-transform-es2015-sticky-regex@^6.24.1:
+babel-plugin-transform-es2015-sticky-regex@^6.22.0:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.24.1.tgz#00c1cdb1aca71112cdf0cf6126c2ed6b457ccdbc"
   dependencies:
@@ -503,13 +566,13 @@ babel-plugin-transform-es2015-template-literals@^6.22.0:
   dependencies:
     babel-runtime "^6.22.0"
 
-babel-plugin-transform-es2015-typeof-symbol@^6.22.0:
+babel-plugin-transform-es2015-typeof-symbol@^6.23.0:
   version "6.23.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.23.0.tgz#dec09f1cddff94b52ac73d505c84df59dcceb372"
   dependencies:
     babel-runtime "^6.22.0"
 
-babel-plugin-transform-es2015-unicode-regex@^6.24.1:
+babel-plugin-transform-es2015-unicode-regex@^6.22.0:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.24.1.tgz#d38b12f42ea7323f729387f18a7c5ae1faeb35e9"
   dependencies:
@@ -517,11 +580,19 @@ babel-plugin-transform-es2015-unicode-regex@^6.24.1:
     babel-runtime "^6.22.0"
     regexpu-core "^2.0.0"
 
-babel-plugin-transform-regenerator@^6.24.1:
+babel-plugin-transform-exponentiation-operator@^6.22.0:
   version "6.24.1"
-  resolved "https://registry.yarnpkg.com/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.24.1.tgz#b8da305ad43c3c99b4848e4fe4037b770d23c418"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-exponentiation-operator/-/babel-plugin-transform-exponentiation-operator-6.24.1.tgz#2ab0c9c7f3098fa48907772bb813fe41e8de3a0e"
   dependencies:
-    regenerator-transform "0.9.11"
+    babel-helper-builder-binary-assignment-operator-visitor "^6.24.1"
+    babel-plugin-syntax-exponentiation-operator "^6.8.0"
+    babel-runtime "^6.22.0"
+
+babel-plugin-transform-regenerator@^6.22.0:
+  version "6.26.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.26.0.tgz#e0703696fbde27f0a3efcacf8b4dca2f7b3a8f2f"
+  dependencies:
+    regenerator-transform "^0.10.0"
 
 babel-plugin-transform-strict-mode@^6.24.1:
   version "6.24.1"
@@ -530,34 +601,40 @@ babel-plugin-transform-strict-mode@^6.24.1:
     babel-runtime "^6.22.0"
     babel-types "^6.24.1"
 
-babel-preset-es2015@^6.18.0:
-  version "6.24.1"
-  resolved "https://registry.yarnpkg.com/babel-preset-es2015/-/babel-preset-es2015-6.24.1.tgz#d44050d6bc2c9feea702aaf38d727a0210538939"
+babel-preset-env@latest:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/babel-preset-env/-/babel-preset-env-1.7.0.tgz#dea79fa4ebeb883cd35dab07e260c1c9c04df77a"
   dependencies:
     babel-plugin-check-es2015-constants "^6.22.0"
+    babel-plugin-syntax-trailing-function-commas "^6.22.0"
+    babel-plugin-transform-async-to-generator "^6.22.0"
     babel-plugin-transform-es2015-arrow-functions "^6.22.0"
     babel-plugin-transform-es2015-block-scoped-functions "^6.22.0"
-    babel-plugin-transform-es2015-block-scoping "^6.24.1"
-    babel-plugin-transform-es2015-classes "^6.24.1"
-    babel-plugin-transform-es2015-computed-properties "^6.24.1"
-    babel-plugin-transform-es2015-destructuring "^6.22.0"
-    babel-plugin-transform-es2015-duplicate-keys "^6.24.1"
-    babel-plugin-transform-es2015-for-of "^6.22.0"
-    babel-plugin-transform-es2015-function-name "^6.24.1"
+    babel-plugin-transform-es2015-block-scoping "^6.23.0"
+    babel-plugin-transform-es2015-classes "^6.23.0"
+    babel-plugin-transform-es2015-computed-properties "^6.22.0"
+    babel-plugin-transform-es2015-destructuring "^6.23.0"
+    babel-plugin-transform-es2015-duplicate-keys "^6.22.0"
+    babel-plugin-transform-es2015-for-of "^6.23.0"
+    babel-plugin-transform-es2015-function-name "^6.22.0"
     babel-plugin-transform-es2015-literals "^6.22.0"
-    babel-plugin-transform-es2015-modules-amd "^6.24.1"
-    babel-plugin-transform-es2015-modules-commonjs "^6.24.1"
-    babel-plugin-transform-es2015-modules-systemjs "^6.24.1"
-    babel-plugin-transform-es2015-modules-umd "^6.24.1"
-    babel-plugin-transform-es2015-object-super "^6.24.1"
-    babel-plugin-transform-es2015-parameters "^6.24.1"
-    babel-plugin-transform-es2015-shorthand-properties "^6.24.1"
+    babel-plugin-transform-es2015-modules-amd "^6.22.0"
+    babel-plugin-transform-es2015-modules-commonjs "^6.23.0"
+    babel-plugin-transform-es2015-modules-systemjs "^6.23.0"
+    babel-plugin-transform-es2015-modules-umd "^6.23.0"
+    babel-plugin-transform-es2015-object-super "^6.22.0"
+    babel-plugin-transform-es2015-parameters "^6.23.0"
+    babel-plugin-transform-es2015-shorthand-properties "^6.22.0"
     babel-plugin-transform-es2015-spread "^6.22.0"
-    babel-plugin-transform-es2015-sticky-regex "^6.24.1"
+    babel-plugin-transform-es2015-sticky-regex "^6.22.0"
     babel-plugin-transform-es2015-template-literals "^6.22.0"
-    babel-plugin-transform-es2015-typeof-symbol "^6.22.0"
-    babel-plugin-transform-es2015-unicode-regex "^6.24.1"
-    babel-plugin-transform-regenerator "^6.24.1"
+    babel-plugin-transform-es2015-typeof-symbol "^6.23.0"
+    babel-plugin-transform-es2015-unicode-regex "^6.22.0"
+    babel-plugin-transform-exponentiation-operator "^6.22.0"
+    babel-plugin-transform-regenerator "^6.22.0"
+    browserslist "^3.2.6"
+    invariant "^2.2.2"
+    semver "^5.3.0"
 
 babel-register@^6.24.1:
   version "6.24.1"
@@ -578,6 +655,13 @@ babel-runtime@^6.18.0, babel-runtime@^6.22.0:
     core-js "^2.4.0"
     regenerator-runtime "^0.10.0"
 
+babel-runtime@^6.26.0:
+  version "6.26.0"
+  resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.26.0.tgz#965c7058668e82b55d7bfe04ff2337bc8b5647fe"
+  dependencies:
+    core-js "^2.4.0"
+    regenerator-runtime "^0.11.0"
+
 babel-template@^6.24.1, babel-template@^6.25.0:
   version "6.25.0"
   resolved "https://registry.yarnpkg.com/babel-template/-/babel-template-6.25.0.tgz#665241166b7c2aa4c619d71e192969552b10c071"
@@ -587,6 +671,16 @@ babel-template@^6.24.1, babel-template@^6.25.0:
     babel-types "^6.25.0"
     babylon "^6.17.2"
     lodash "^4.2.0"
+
+babel-template@^6.26.0:
+  version "6.26.0"
+  resolved "https://registry.yarnpkg.com/babel-template/-/babel-template-6.26.0.tgz#de03e2d16396b069f46dd9fff8521fb1a0e35e02"
+  dependencies:
+    babel-runtime "^6.26.0"
+    babel-traverse "^6.26.0"
+    babel-types "^6.26.0"
+    babylon "^6.18.0"
+    lodash "^4.17.4"
 
 babel-traverse@^6.24.1, babel-traverse@^6.25.0:
   version "6.25.0"
@@ -602,6 +696,20 @@ babel-traverse@^6.24.1, babel-traverse@^6.25.0:
     invariant "^2.2.0"
     lodash "^4.2.0"
 
+babel-traverse@^6.26.0:
+  version "6.26.0"
+  resolved "https://registry.yarnpkg.com/babel-traverse/-/babel-traverse-6.26.0.tgz#46a9cbd7edcc62c8e5c064e2d2d8d0f4035766ee"
+  dependencies:
+    babel-code-frame "^6.26.0"
+    babel-messages "^6.23.0"
+    babel-runtime "^6.26.0"
+    babel-types "^6.26.0"
+    babylon "^6.18.0"
+    debug "^2.6.8"
+    globals "^9.18.0"
+    invariant "^2.2.2"
+    lodash "^4.17.4"
+
 babel-types@^6.19.0, babel-types@^6.24.1, babel-types@^6.25.0:
   version "6.25.0"
   resolved "https://registry.yarnpkg.com/babel-types/-/babel-types-6.25.0.tgz#70afb248d5660e5d18f811d91c8303b54134a18e"
@@ -611,9 +719,22 @@ babel-types@^6.19.0, babel-types@^6.24.1, babel-types@^6.25.0:
     lodash "^4.2.0"
     to-fast-properties "^1.0.1"
 
+babel-types@^6.26.0:
+  version "6.26.0"
+  resolved "https://registry.yarnpkg.com/babel-types/-/babel-types-6.26.0.tgz#a3b073f94ab49eb6fa55cd65227a334380632497"
+  dependencies:
+    babel-runtime "^6.26.0"
+    esutils "^2.0.2"
+    lodash "^4.17.4"
+    to-fast-properties "^1.0.3"
+
 babylon@^6.17.2:
   version "6.17.4"
   resolved "https://registry.yarnpkg.com/babylon/-/babylon-6.17.4.tgz#3e8b7402b88d22c3423e137a1577883b15ff869a"
+
+babylon@^6.18.0:
+  version "6.18.0"
+  resolved "https://registry.yarnpkg.com/babylon/-/babylon-6.18.0.tgz#af2f3b88fa6f5c1e4c634d1a0f8eac4f55b395e3"
 
 balanced-match@^0.4.2:
   version "0.4.2"
@@ -804,6 +925,13 @@ browserslist@^1.3.6, browserslist@^1.5.2, browserslist@^1.7.6:
     caniuse-db "^1.0.30000639"
     electron-to-chromium "^1.2.7"
 
+browserslist@^3.2.6:
+  version "3.2.8"
+  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-3.2.8.tgz#b0005361d6471f0f5952797a76fc985f1f978fc6"
+  dependencies:
+    caniuse-lite "^1.0.30000844"
+    electron-to-chromium "^1.3.47"
+
 buffer-crc32@~0.2.3:
   version "0.2.13"
   resolved "https://registry.yarnpkg.com/buffer-crc32/-/buffer-crc32-0.2.13.tgz#0d333e3f00eac50aa1454abd30ef8c2a5d9a7242"
@@ -879,6 +1007,10 @@ caniuse-api@^1.5.2:
 caniuse-db@^1.0.30000529, caniuse-db@^1.0.30000634, caniuse-db@^1.0.30000639:
   version "1.0.30000693"
   resolved "https://registry.yarnpkg.com/caniuse-db/-/caniuse-db-1.0.30000693.tgz#8510e7a9ab04adcca23a5dcefa34df9d28c1ce20"
+
+caniuse-lite@^1.0.30000844:
+  version "1.0.30000865"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000865.tgz#70026616e8afe6e1442f8bb4e1092987d81a2f25"
 
 capture-stack-trace@^1.0.0:
   version "1.0.0"
@@ -1577,6 +1709,10 @@ electron-to-chromium@^1.2.7:
   version "1.3.14"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.14.tgz#64af0f9efd3c3c6acd57d71f83b49ca7ee9c4b43"
 
+electron-to-chromium@^1.3.47:
+  version "1.3.52"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.52.tgz#d2d9f1270ba4a3b967b831c40ef71fb4d9ab5ce0"
+
 elliptic@^6.0.0:
   version "6.4.0"
   resolved "https://registry.yarnpkg.com/elliptic/-/elliptic-6.4.0.tgz#cac9af8762c85836187003c8dfe193e5e2eae5df"
@@ -2091,7 +2227,7 @@ glob@^7.0.0, glob@^7.0.3, glob@^7.0.5, glob@~7.1.1:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-globals@^9.0.0:
+globals@^9.0.0, globals@^9.18.0:
   version "9.18.0"
   resolved "https://registry.yarnpkg.com/globals/-/globals-9.18.0.tgz#aa3896b3e69b487f17e31ed2143d69a8e30c2d8a"
 
@@ -2494,6 +2630,12 @@ invariant@^2.2.0:
   dependencies:
     loose-envify "^1.0.0"
 
+invariant@^2.2.2:
+  version "2.2.4"
+  resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.4.tgz#610f3c92c9359ce1db616e538008d23ff35158e6"
+  dependencies:
+    loose-envify "^1.0.0"
+
 invert-kv@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/invert-kv/-/invert-kv-1.0.0.tgz#104a8e4aaca6d3d8cd157a8ef8bfab2d7a3ffdb6"
@@ -2713,6 +2855,10 @@ js-base64@^2.1.8, js-base64@^2.1.9:
 js-tokens@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.1.tgz#08e9f132484a2c45a30907e9dc4d5567b7f114d7"
+
+js-tokens@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
 
 js-yaml@~3.7.0:
   version "3.7.0"
@@ -2961,6 +3107,10 @@ lodash.uniq@^4.5.0:
 lodash@^4.0.0, lodash@^4.14.0, lodash@^4.17.2, lodash@^4.17.3, lodash@^4.2.0, lodash@^4.3.0, lodash@~4.17.4:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
+
+lodash@^4.17.4:
+  version "4.17.10"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.10.tgz#1b7793cf7259ea38fb3661d4d38b3260af8ae4e7"
 
 logalot@^2.0.0:
   version "2.1.0"
@@ -4050,9 +4200,13 @@ regenerator-runtime@^0.10.0:
   version "0.10.5"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz#336c3efc1220adcedda2c9fab67b5a7955a33658"
 
-regenerator-transform@0.9.11:
-  version "0.9.11"
-  resolved "https://registry.yarnpkg.com/regenerator-transform/-/regenerator-transform-0.9.11.tgz#3a7d067520cb7b7176769eb5ff868691befe1283"
+regenerator-runtime@^0.11.0:
+  version "0.11.1"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz#be05ad7f9bf7d22e056f9726cee5017fbf19e2e9"
+
+regenerator-transform@^0.10.0:
+  version "0.10.1"
+  resolved "https://registry.yarnpkg.com/regenerator-transform/-/regenerator-transform-0.10.1.tgz#1e4996837231da8b7f3cf4114d71b5691a0680dd"
   dependencies:
     babel-runtime "^6.18.0"
     babel-types "^6.19.0"
@@ -4691,7 +4845,7 @@ to-arraybuffer@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/to-arraybuffer/-/to-arraybuffer-1.0.1.tgz#7d229b1fcc637e466ca081180836a7aabff83f43"
 
-to-fast-properties@^1.0.1:
+to-fast-properties@^1.0.1, to-fast-properties@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/to-fast-properties/-/to-fast-properties-1.0.3.tgz#b83571fa4d8c25b82e231b06e3a3055de4ca1a47"
 


### PR DESCRIPTION
**Done**:

- Added media stream API support for IOS devices & show capture picture icon, which will work if user opens in browser not from add to homescreen.
- When launching the app from homescreen in **iOS devices**, scanning wont work since the webkit webview for homescreen doesn't support mediaStream API. So I have added a capture icon to make it work for now.
- Using https://github.com/GoogleChromeLabs/pwacompat to provide splash support for ios and other old browsers
- Added netlify deployment support for each branch.

Since I am iOS 12 public beta 4, capture the picture to scan is not working for me using newly added icon. I need someone to test it out and let me know if we can go ahead with above PR.

