### PR TITLE
Fix for the samsung S20

### DIFF
--- a/app/js/vendor/qrscan.js
+++ b/app/js/vendor/qrscan.js
@@ -85,7 +85,7 @@ QRReader.init = () => {
           constraints = {
             video: {
               mandatory: {
-                sourceId: device[1].deviceId ? device[1].deviceId : null
+                sourceId: device[device.length - 1].deviceId ? device[device.length - 1].deviceId : null
               }
             },
             audio: false


### PR DESCRIPTION
I noticed that rear camera are listed at the end, so sourceId is now getting latest id in the devices list.
Tested on samsugn S20, J20, umidigi one pro, opera desktop.
https://github.com/code-kotis/qr-code-scanner/issues/92